### PR TITLE
Update repo in meta-netkan

### DIFF
--- a/CKAN/DeployableEngines.netkan
+++ b/CKAN/DeployableEngines.netkan
@@ -3,12 +3,12 @@
     "identifier":   "DeployableEngines",
     "abstract":     "A plugin to manage extending/retracting engine nozzles",
     "name":         "Deployable Engines Plugin",
-    "$kref":        "#/ckan/github/ChrisAdderley/DeployableEngines",
+    "$kref":        "#/ckan/github/post-kerbin-mining-corporation/DeployableEngines",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "MIT",
     "resources": {
-      "homepage": "https://github.com/ChrisAdderley/DeployableEngines/wiki",
-      "repository": "https://github.com/ChrisAdderley/DeployableEngines"
+      "homepage": "https://github.com/post-kerbin-mining-corporation/DeployableEngines/wiki",
+      "repository": "https://github.com/post-kerbin-mining-corporation/DeployableEngines"
     },
     "supports": [
         { "name": "KerbalAtomics" },


### PR DESCRIPTION
GitHub likes to throw bogus API rate limiting errors when the CKAN bot crawls mods after their repositories change.
Now this is updated from ChrisAdderley to post-kerbin-mining-corporation.

Previously updated the link to the meta-netkans in KSP-CKAN/NetKAN#8264.

Tagging @ChrisAdderley because GitHub is shy about sending notifications for pull requests.